### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://biprasad10.visualstudio.com/1228762b-879c-479b-92b9-47f4d1bd2c9f/f8a3266d-b97e-439d-a332-c8a682134ddd/_apis/work/boardbadge/e44b75c8-4af3-4ab5-8f79-f6082715f434)](https://biprasad10.visualstudio.com/1228762b-879c-479b-92b9-47f4d1bd2c9f/_boards/board/t/f8a3266d-b97e-439d-a332-c8a682134ddd/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://biprasad10.visualstudio.com/1228762b-879c-479b-92b9-47f4d1bd2c9f/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.